### PR TITLE
#166315332  add a readme file with build/coverage status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Build Status](https://travis-ci.org/newdevtech/newdev_api.svg?branch=develop)](https://travis-ci.org/newdevtech/newdev_api) [![Coverage Status](https://coveralls.io/repos/github/newdevtech/newdev_api/badge.svg?branch=develop)](https://coveralls.io/github/newdevtech/newdev_api?branch=develop)


### PR DESCRIPTION
#### What does this PR do?
- adds a readme file that displays the status of your build/coverage upon a PR

#### Description of Task to be completed?
- create a `README.md` file
- add the status as a markdown file

#### How should this be manually tested?
- after raising a PR, check to see if it passed or failed

#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories?
#166315332

#### Screenshots (if appropriate)

#### Questions: