### PR TITLE
#166487866 Implement getTechnology feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clean": "rm -rf build",
     "db:migrate": "sequelize db:migrate",
     "db:undo:migrate": "sequelize db:migrate:undo:all",
+    "db:roll:migrate": "npm run db:undo:migrate && npm run db:migrate && npm run db:seed",
     "db:seed": "node_modules/.bin/sequelize db:seed:all $* --seeders-path src/database/seeders/",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },

--- a/src/app/category/controller.js
+++ b/src/app/category/controller.js
@@ -5,7 +5,7 @@ const { Category, Technology } = models;
 const createcategory = async (req, res) => {
   const { name } = req.body;
   const category = await Category.create({
-    name: name.toLowerCase(),
+    name: name.toLowerCase().trim(),
   });
 
   return res.status(201).json({
@@ -30,7 +30,7 @@ const getcategories = async (req, res) => {
   });
 };
 
-const getSinglecategory = async (req, res) => {
+const getSingleCategory = async (req, res) => {
   const { name } = req.params;
   const category = await Category.findOne({
     where: { name },
@@ -46,4 +46,4 @@ const getSinglecategory = async (req, res) => {
   });
 };
 
-export { createcategory, getcategories, getSinglecategory };
+export { createcategory, getcategories, getSingleCategory };

--- a/src/app/category/middleware.js
+++ b/src/app/category/middleware.js
@@ -21,7 +21,7 @@ const isNameUnique = (req, res, next) => {
   uniqueParamValidator({ name }, 'Category', next);
 };
 
-const doescategoryExist = (req, res, next) => {
+const doesCategoryExist = (req, res, next) => {
   notFoundRowValidator(req, 'Category', next);
 };
 
@@ -29,5 +29,5 @@ export {
   areRequiredParamsPresent,
   areTypesValid,
   isNameUnique,
-  doescategoryExist,
+  doesCategoryExist,
 };

--- a/src/app/category/routes.js
+++ b/src/app/category/routes.js
@@ -1,11 +1,11 @@
 import express from 'express';
-import { createcategory, getcategories, getSinglecategory } from './controller';
+import { createcategory, getcategories, getSingleCategory } from './controller';
 import { isUserAdmin, isTokenValid } from '../../common';
 import {
   areRequiredParamsPresent,
   areTypesValid,
   isNameUnique,
-  doescategoryExist,
+  doesCategoryExist,
 } from './middleware';
 
 const categoryRoutes = express.Router();
@@ -22,7 +22,6 @@ categoryRoutes
   );
 
 categoryRoutes.route('/').get(getcategories);
-
-categoryRoutes.route('/:name').get(doescategoryExist, getSinglecategory);
+categoryRoutes.route('/:name').get(doesCategoryExist, getSingleCategory);
 
 export default categoryRoutes;

--- a/src/app/technology/controller.js
+++ b/src/app/technology/controller.js
@@ -1,6 +1,8 @@
+import Sequelize from 'sequelize';
 import models from '../../database/models';
 
-const { Technology } = models;
+const { Technology, Topic } = models;
+const { iLike } = Sequelize.Op;
 
 const addTechnology = async (req, res) => {
   const { name, category } = req.body;
@@ -20,4 +22,36 @@ const addTechnology = async (req, res) => {
   });
 };
 
-export default addTechnology;
+const getTechnologies = async (req, res) => {
+  const technologies = await Technology.findAndCountAll({
+    order: [['createdAt', 'DESC']],
+    include: [
+      {
+        model: Topic,
+      },
+    ],
+  });
+
+  return res.status(200).json({
+    technologies: technologies.rows,
+    count: technologies.count,
+  });
+};
+
+const getSingleTechnology = async (req, res) => {
+  const { name } = req.params;
+  const technology = await Technology.findOne({
+    where: { name: { [iLike]: name } },
+    include: [
+      {
+        model: Topic,
+      },
+    ],
+  });
+
+  return res.status(200).json({
+    technology,
+  });
+};
+
+export { addTechnology, getTechnologies, getSingleTechnology };

--- a/src/app/technology/middleware.js
+++ b/src/app/technology/middleware.js
@@ -3,6 +3,7 @@ import {
   typeValidator,
   referencedParamValidator,
   uniqueParamValidator,
+  notFoundRowValidator,
 } from '../../common';
 
 const areRequiredParamsPresent = (req, res, next) => {
@@ -28,9 +29,14 @@ const isCategoryExisting = (req, res, next) => {
   );
 };
 
+const doesTechnologyExist = (req, res, next) => {
+  notFoundRowValidator(req, 'Technology', next);
+};
+
 export {
   areRequiredParamsPresent,
   areTypesValid,
   isNameUnique,
   isCategoryExisting,
+  doesTechnologyExist,
 };

--- a/src/app/technology/routes.js
+++ b/src/app/technology/routes.js
@@ -1,11 +1,16 @@
 import express from 'express';
-import addTechnology from './controller';
 import { isUserAdmin, isTokenValid } from '../../common';
+import {
+  addTechnology,
+  getTechnologies,
+  getSingleTechnology,
+} from './controller';
 import {
   areRequiredParamsPresent,
   areTypesValid,
   isNameUnique,
   isCategoryExisting,
+  doesTechnologyExist,
 } from './middleware';
 
 const technologyRoutes = express.Router();
@@ -21,5 +26,8 @@ technologyRoutes
     isCategoryExisting,
     addTechnology,
   );
+
+technologyRoutes.route('/').get(getTechnologies);
+technologyRoutes.route('/:name').get(doesTechnologyExist, getSingleTechnology);
 
 export default technologyRoutes;

--- a/src/common/middleware/roleValidation.js
+++ b/src/common/middleware/roleValidation.js
@@ -8,7 +8,7 @@ const validateRole = async (req, userRole, next) => {
   const error = new Error(
     `You must have role: [${userRole}] to access this route`,
   );
-  error.status = 400;
+  error.status = 401;
   const validUser = await User.findOne({
     where: {
       id,

--- a/src/database/models/topic.js
+++ b/src/database/models/topic.js
@@ -22,13 +22,13 @@ export default (sequelize, DataTypes) => {
       foreignKey: 'technology',
     });
     Topic.belongsTo(models.Proficiency, {
-      foreignKey: 'topicId',
+      foreignKey: 'id',
     });
     Topic.hasMany(models.Resource, {
-      foreignKey: 'topicId',
+      foreignKey: 'id',
     });
     Topic.hasMany(models.Subtopic, {
-      foreignKey: 'topicId',
+      foreignKey: 'id',
     });
   };
 

--- a/src/database/seeders/004-default-topics.js
+++ b/src/database/seeders/004-default-topics.js
@@ -1,0 +1,39 @@
+module.exports = {
+  up: queryInterface =>
+    queryInterface.bulkInsert(
+      'Topics',
+      [
+        {
+          id: 11111,
+          name: 'JavaScript Arrays',
+          technology: 'javascript',
+          createdAt: '2019-06-08 009:10:38.181+01',
+          updatedAt: '2019-06-08 009:10:38.181+01',
+        },
+        {
+          id: 22222,
+          name: 'Python Functions',
+          technology: 'python',
+          createdAt: '2019-06-08 009:10:38.181+01',
+          updatedAt: '2019-06-08 009:10:38.181+01',
+        },
+        {
+          id: 33333,
+          name: 'HTML Forms',
+          technology: 'html',
+          createdAt: '2019-06-08 009:10:38.181+01',
+          updatedAt: '2019-06-08 009:10:38.181+01',
+        },
+        {
+          id: 44444,
+          name: 'JavaScript Objects',
+          technology: 'javascript',
+          createdAt: '2019-06-08 009:10:38.181+01',
+          updatedAt: '2019-06-08 009:10:38.181+01',
+        },
+      ],
+      {},
+    ),
+
+  down: queryInterface => queryInterface.bulkDelete('Topics', null, {}),
+};


### PR DESCRIPTION
#### What does this PR do?
- adds getAllTechnology controller
- adds getTechnology controller
- adds default seed data for topic model
- adds middleware for getTechnology route
- adds roll:migrate script to package.json

#### Description of Task to be completed?
- As a user, I should be able to get the existing technologies

#### How should this be manually tested?
- run `db:roll:migrate` to roll your migrations `plus` seed default the data
- send a `GET` request to `/technologies` to get all technologies in the database
- send a `GET` request to `/technologies/:name` to get a single technology

#### What are the relevant pivotal tracker stories?
[#166487866](https://www.pivotaltracker.com/story/show/166487866)