### PR TITLE
#166487572 Add create-subtopic functionality

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -2,5 +2,12 @@ import userRoutes from './user';
 import categoryRoutes from './category';
 import technologyRoutes from './technology';
 import topicRoutes from './topic';
+import subtopicRoutes from './subtopic';
 
-export { userRoutes, categoryRoutes, technologyRoutes, topicRoutes };
+export {
+  userRoutes,
+  categoryRoutes,
+  technologyRoutes,
+  topicRoutes,
+  subtopicRoutes,
+};

--- a/src/app/subtopic/_tests_/subtopic.spec.js
+++ b/src/app/subtopic/_tests_/subtopic.spec.js
@@ -5,11 +5,10 @@ import server from '../../../index';
 
 chai.use(chaiHttp);
 
-const { Category } = models;
+const { Category, Technology, Topic, Subtopic } = models;
 
-let newTechnology;
-let adminUser;
-const baseUrl = '/api/v1';
+let adminUser, existingTopicId, existingSubtopicName;
+const baseUrl = '/api/v1/subtopics';
 const userRequestObject = {
   username: 'buttercup',
   email: 'buttercup@puffmail.com',
@@ -28,71 +27,45 @@ describe('Topic test suite', () => {
     await Category.create({
       name: 'backend',
     });
-
-    const requestObject = {
+    await Technology.create({
       name: 'c#',
       category: 'backend',
-    };
-    newTechnology = (await chai
-      .request(server)
-      .post('/api/v1/technologies')
-      .set('Authorization', adminUser.token)
-      .send(requestObject)).body.technology;
-  });
-
-  describe('Add Topic', () => {
-    it('should successfully create a topic', async () => {
-      const requestObject = {
-        name: 'Random topic',
-        technology: 'c#',
-      };
-      const response = await chai
-        .request(server)
-        .post(`${baseUrl}/topics`)
-        .set('Authorization', adminUser.token)
-        .send(requestObject);
-      expect(response.body.message).to.equal('Sucessfully added Topic!');
-      expect(response.status).to.equal(201);
     });
+    const newTopic = await Topic.create({
+      name: 'Control statements',
+      technology: 'c#',
+    });
+    existingTopicId = newTopic.dataValues.id;
+    const newSubtopic = await Subtopic.create({
+      name: 'How to handle control statements',
+      topicId: existingTopicId,
+    });
+    existingSubtopicName = newSubtopic.dataValues.name;
   });
 
-  describe('Topic Input Validations', () => {
-    it('should not create topic with non-existing technology', async () => {
+  describe('Subtopic Input Validations', () => {
+    it('should not create subtopic with nonexistent topic', async () => {
       const requestObject = {
-        name: 'New html topic',
-        technology: 'blockchain',
+        name: 'How to handle namespaces',
+        topicId: 'nonexistent-id',
       };
       const response = await chai
         .request(server)
-        .post(`${baseUrl}/topics`)
+        .post(`${baseUrl}`)
         .set('Authorization', adminUser.token)
         .send(requestObject);
-      const errorMessage = 'Technology with name: blockchain does not exist';
+      const errorMessage = 'Topic with id: nonexistent-id does not exist';
       expect(response.body.error).to.equal(errorMessage);
       expect(response.status).to.equal(404);
     });
 
-    it('should not create topic without a name field', async () => {
+    it('should not create subtopic without a name field', async () => {
       const requestObject = {
-        name: 'Threading',
+        topicId: existingTopicId,
       };
       const response = await chai
         .request(server)
-        .post(`${baseUrl}/topics`)
-        .set('Authorization', adminUser.token)
-        .send(requestObject);
-      const errorMessage = 'technology is required';
-      expect(response.body.error).to.equal(errorMessage);
-      expect(response.status).to.equal(400);
-    });
-
-    it('should not create topic without a name field', async () => {
-      const requestObject = {
-        technology: 'html',
-      };
-      const response = await chai
-        .request(server)
-        .post(`${baseUrl}/topics`)
+        .post(`${baseUrl}`)
         .set('Authorization', adminUser.token)
         .send(requestObject);
       const errorMessage = 'name is required';
@@ -100,14 +73,28 @@ describe('Topic test suite', () => {
       expect(response.status).to.equal(400);
     });
 
-    it('should not create topic with an empty name field', async () => {
+    it('should not create a subtopic without a topicId field', async () => {
       const requestObject = {
-        name: '',
-        technology: 'html',
+        name: 'How threading works',
       };
       const response = await chai
         .request(server)
-        .post(`${baseUrl}/topics`)
+        .post(`${baseUrl}`)
+        .set('Authorization', adminUser.token)
+        .send(requestObject);
+      const errorMessage = 'topicId is required';
+      expect(response.body.error).to.equal(errorMessage);
+      expect(response.status).to.equal(400);
+    });
+
+    it('should not create a subtopic with an empty name field', async () => {
+      const requestObject = {
+        name: '',
+        topicId: existingTopicId,
+      };
+      const response = await chai
+        .request(server)
+        .post(`${baseUrl}`)
         .set('Authorization', adminUser.token)
         .send(requestObject);
       const errorMessage = 'name must not be empty';
@@ -115,29 +102,30 @@ describe('Topic test suite', () => {
       expect(response.status).to.equal(400);
     });
 
-    it('should not create topic with an empty technology field', async () => {
+    it('should not create topic with an empty topicId field', async () => {
       const requestObject = {
-        name: 'New topic',
-        technology: '',
+        name: 'How threading works',
+        topicId: '',
       };
       const response = await chai
         .request(server)
-        .post(`${baseUrl}/topics`)
+        .post(`${baseUrl}`)
         .set('Authorization', adminUser.token)
         .send(requestObject);
-      const errorMessage = 'technology must not be empty';
+      const errorMessage = 'topicId must not be empty';
       expect(response.body.error).to.equal(errorMessage);
       expect(response.status).to.equal(400);
     });
 
-    it('should not create topic with a non-string name input', async () => {
+    // eslint-disable-next-line max-len
+    it('should not create a subtopic with a non-string name input', async () => {
       const requestObject = {
         name: 88888,
-        technology: 'html',
+        topicId: 'html',
       };
       const response = await chai
         .request(server)
-        .post(`${baseUrl}/topics`)
+        .post(`${baseUrl}`)
         .set('Authorization', adminUser.token)
         .send(requestObject);
       const errorMessage = '[name] must be of type: string';
@@ -145,37 +133,52 @@ describe('Topic test suite', () => {
       expect(response.status).to.equal(400);
     });
 
-    it('should not create topic with a non-string technology', async () => {
+    it('should not create topic with a non-string topicId input', async () => {
       const requestObject = {
         name: 'New topic',
-        technology: 88888,
+        topicId: 88888,
       };
       const response = await chai
         .request(server)
-        .post(`${baseUrl}/topics`)
+        .post(`${baseUrl}`)
         .set('Authorization', adminUser.token)
         .send(requestObject);
-      const errorMessage = '[technology] must be of type: string';
+      const errorMessage = '[topicId] must be of type: string';
       expect(response.body.error).to.equal(errorMessage);
       expect(response.status).to.equal(400);
     });
 
-    it('should not create same topic with the same technology', async () => {
+    it('should not create same subtopic with same topic', async () => {
       const requestObject = {
-        name: 'Random topic',
-        technology: newTechnology.name,
+        name: existingSubtopicName,
+        topicId: existingTopicId,
       };
       const response = await chai
         .request(server)
-        .post(`${baseUrl}/topics`)
+        .post(`${baseUrl}`)
         .set('Authorization', adminUser.token)
         .send(requestObject);
-      // eslint-disable-next-line max-len
-      const errorMessage = `${
-        requestObject.name
-      } already exists for technology: ${newTechnology.name}`;
+      const errorMessage = `${requestObject.name} already exists for topicId: ${
+        requestObject.topicId
+      }`;
       expect(response.body.error).to.equal(errorMessage);
       expect(response.status).to.equal(409);
+    });
+  });
+
+  describe('Add Topic', () => {
+    it('should successfully create a subtopic', async () => {
+      const requestObject = {
+        name: 'How to declare arrays',
+        topicId: existingTopicId,
+      };
+      const response = await chai
+        .request(server)
+        .post(`${baseUrl}`)
+        .set('Authorization', adminUser.token)
+        .send(requestObject);
+      expect(response.body.message).to.equal('Sucessfully added Subtopic!');
+      expect(response.status).to.equal(201);
     });
   });
 });

--- a/src/app/subtopic/controller.js
+++ b/src/app/subtopic/controller.js
@@ -1,0 +1,17 @@
+import models from '../../database/models';
+
+const { Subtopic } = models;
+
+const createSubtopic = async (req, res) => {
+  const { name, topicId } = req.body;
+  const subtopic = await Subtopic.create({
+    name: name.toLowerCase().trim(),
+    topicId: topicId.toLowerCase().trim(),
+  });
+  return res.status(201).json({
+    message: 'Sucessfully added Subtopic!',
+    subtopic,
+  });
+};
+
+export default createSubtopic;

--- a/src/app/subtopic/index.js
+++ b/src/app/subtopic/index.js
@@ -1,0 +1,1 @@
+export { default } from './routes';

--- a/src/app/subtopic/middleware.js
+++ b/src/app/subtopic/middleware.js
@@ -1,0 +1,40 @@
+import {
+  requiredParamsValidator,
+  typeValidator,
+  referencedParamValidator,
+  relationalValidator,
+} from '../../common';
+
+const areRequiredParamsPresent = (req, res, next) => {
+  const requiredParams = ['name', 'topicId'];
+  return requiredParamsValidator(req.body, requiredParams, next);
+};
+
+const areTypesValid = (req, res, next) => {
+  const { name, topicId } = req.body;
+  const stringParams = { name, topicId };
+  return typeValidator(stringParams, 'string', next);
+};
+
+const doesTopicExist = (req, res, next) => {
+  referencedParamValidator({ id: req.body.topicId.trim() }, 'Topic', next);
+};
+
+const isNameUniqueForTopic = (req, res, next) => {
+  const { name, topicId } = req.body;
+  relationalValidator(
+    {
+      name: name.trim(),
+      topicId: topicId.trim(),
+    },
+    'Subtopic',
+    next,
+  );
+};
+
+export {
+  areRequiredParamsPresent,
+  areTypesValid,
+  doesTopicExist,
+  isNameUniqueForTopic,
+};

--- a/src/app/subtopic/routes.js
+++ b/src/app/subtopic/routes.js
@@ -1,0 +1,25 @@
+import express from 'express';
+import createSubtopic from './controller';
+import { isUserAdmin, isTokenValid } from '../../common';
+import {
+  areRequiredParamsPresent,
+  areTypesValid,
+  doesTopicExist,
+  isNameUniqueForTopic,
+} from './middleware';
+
+const subtopicRoutes = express.Router();
+
+subtopicRoutes
+  .route('/')
+  .post(
+    isTokenValid,
+    isUserAdmin,
+    areRequiredParamsPresent,
+    areTypesValid,
+    doesTopicExist,
+    isNameUniqueForTopic,
+    createSubtopic,
+  );
+
+export default subtopicRoutes;

--- a/src/app/technology/_tests_/technology.spec.js
+++ b/src/app/technology/_tests_/technology.spec.js
@@ -99,7 +99,7 @@ describe('Technology Test Suite', () => {
         category: 'notepad',
       };
       const response = await addTechnology(requestObject, adminToken);
-      const errorMessage = 'Category notepad does not exist';
+      const errorMessage = 'Category with name: notepad does not exist';
       expect(response.body.error).to.equal(errorMessage);
       expect(response.status).to.equal(404);
     });

--- a/src/common/helpers/paramValidator.js
+++ b/src/common/helpers/paramValidator.js
@@ -81,7 +81,9 @@ const referencedParamValidator = async (param, model, next) => {
   });
 
   if (!paramExists) {
-    const error = new Error(`${model} ${paramValue} does not exist`);
+    const error = new Error(
+      `${model} with ${paramKey}: ${paramValue} does not exist`,
+    );
     error.status = 404;
     return next(error);
   }
@@ -100,7 +102,7 @@ const relationalValidator = async (params, model, next) => {
 
   if (rowExists) {
     const error = new Error(
-      `${paramsValue[0]} already exists for ${paramsValue[1]}`,
+      `${paramsValue[0]} already exists for ${paramsKey[1]}: ${paramsValue[1]}`,
     );
     error.status = 409;
     return next(error);

--- a/src/database/models/subtopic.js
+++ b/src/database/models/subtopic.js
@@ -17,7 +17,7 @@ export default (sequelize, DataTypes) => {
 
   Subtopic.associate = models => {
     Subtopic.belongsTo(models.Topic, {
-      foreignKey: 'id',
+      foreignKey: 'topicId',
     });
   };
 

--- a/src/database/models/topic.js
+++ b/src/database/models/topic.js
@@ -1,12 +1,10 @@
-import shortid from 'shortid';
-
 export default (sequelize, DataTypes) => {
   const Topic = sequelize.define('Topic', {
     id: {
       allowNull: false,
       primaryKey: true,
       type: DataTypes.STRING,
-      defaultValue: shortid.generate(),
+      defaultValue: DataTypes.UUIDV4,
     },
     name: {
       allowNull: false,
@@ -28,7 +26,7 @@ export default (sequelize, DataTypes) => {
       foreignKey: 'id',
     });
     Topic.hasMany(models.Subtopic, {
-      foreignKey: 'id',
+      foreignKey: 'topicId',
     });
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import {
   categoryRoutes,
   technologyRoutes,
   topicRoutes,
+  subtopicRoutes,
 } from './app';
 import { notFoundRoute, errorHandler } from './common';
 import { Api } from '../docs';
@@ -40,6 +41,7 @@ app.use('/api/v1/users', userRoutes);
 app.use('/api/v1/categories', categoryRoutes);
 app.use('/api/v1/technologies', technologyRoutes);
 app.use('/api/v1/topics', topicRoutes);
+app.use('/api/v1/subtopics', subtopicRoutes);
 app.use(notFoundRoute);
 app.use(errorHandler);
 


### PR DESCRIPTION
#### What does this PR do?
- adds createSubtopic controller
- adds middleware for subtopic
- adds route for subtopic
- refactors error message for referencedParamValidator
- refactors error message for relationalParamValidator

#### Description of Task to be completed?
- As an admin, I should be able to add a sub-topic to a particular topic.

#### Acceptance criteria
- As an admin, I should be able to send a POST request to /api/v1/subtopics with required fields as defined in the subtopics model file.
- The route should only be accessed by an admin or super admin
- I should receive an error message if the topicId field input does not exist in the database topic table
- I should receive an error message if the input fields have invalid types
- I should receive an error message if the name input field with topicId  already exists in our database

#### How should this be manually tested?
- send a `POST` request to `api/v1/subtopics` with the required params as defined in the `Subtopic` model
- Test that the functionality meets the acceptance criteria as defined above.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#166487572](https://www.pivotaltracker.com/story/show/166487572)