### PR TITLE
#166487873 Implement create read functionality for reviews

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -4,6 +4,7 @@ import technologyRoutes from './technology';
 import topicRoutes from './topic';
 import subtopicRoutes from './subtopic';
 import resourceRoutes from './resource';
+import reviewRoutes from './review';
 
 export {
   userRoutes,
@@ -12,4 +13,5 @@ export {
   topicRoutes,
   subtopicRoutes,
   resourceRoutes,
+  reviewRoutes,
 };

--- a/src/app/review/_tests_/resource.spec.js
+++ b/src/app/review/_tests_/resource.spec.js
@@ -1,0 +1,185 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import models from '../../../database/models';
+import server from '../../../index';
+
+chai.use(chaiHttp);
+
+const { Category, Technology, Topic, Resource } = models;
+
+let adminUser, existingTopicId, existingResourceId;
+const baseUrl = '/api/v1/reviews';
+const userRequestObject = {
+  username: 'buttercup',
+  email: 'buttercup@puffmail.com',
+  firstName: 'butter',
+  password: 'superbuttercup',
+  role: 'admin',
+};
+
+describe('Review test suite', () => {
+  before(async () => {
+    await models.sequelize.sync({ force: true });
+    adminUser = (await chai
+      .request(server)
+      .post('/api/v1/users/auth/signup')
+      .send(userRequestObject)).body;
+    await Category.create({
+      name: 'backend',
+    });
+    await Technology.create({
+      name: 'c#',
+      category: 'backend',
+    });
+    const newTopic = await Topic.create({
+      name: 'Control statements',
+      technology: 'c#',
+    });
+    existingTopicId = newTopic.dataValues.id;
+    const newResource = await Resource.create({
+      topicId: existingTopicId,
+      resourceType: 'video',
+      title: 'Handling control statements in C#',
+      author: 'Bugs Burney',
+      url: 'https://randomurl.com/resource',
+    });
+    existingResourceId = newResource.dataValues.id;
+  });
+
+  describe('Review Input Validations', () => {
+    it('should not create review with nonexistent resource', async () => {
+      const requestObject = {
+        resourceId: 'nonexistent-id',
+        review: `The video was a little bit too fast.
+          The tutor assumed a lot about me`,
+      };
+      const response = await chai
+        .request(server)
+        .post(`${baseUrl}`)
+        .set('Authorization', adminUser.token)
+        .send(requestObject);
+      const errorMessage = 'Resource with id: nonexistent-id does not exist';
+      expect(response.body.error).to.equal(errorMessage);
+      expect(response.status).to.equal(404);
+    });
+
+    it('should not create review with missing required field', async () => {
+      const requestObject = {
+        resourceId: existingResourceId,
+      };
+      const response = await chai
+        .request(server)
+        .post(`${baseUrl}`)
+        .set('Authorization', adminUser.token)
+        .send(requestObject);
+      const errorMessage = 'review is required';
+      expect(response.body.error).to.equal(errorMessage);
+      expect(response.status).to.equal(400);
+    });
+
+    it('should not create review with an empty required field', async () => {
+      const requestObject = {
+        resourceId: existingResourceId,
+        review: '',
+      };
+      const response = await chai
+        .request(server)
+        .post(`${baseUrl}`)
+        .set('Authorization', adminUser.token)
+        .send(requestObject);
+      const errorMessage = 'review must not be empty';
+      expect(response.body.error).to.equal(errorMessage);
+      expect(response.status).to.equal(400);
+    });
+
+    // eslint-disable-next-line max-len
+    it('should not create review with a non-string resourceId input', async () => {
+      const requestObject = {
+        resourceId: [existingResourceId],
+        review: `The video was a little bit too fast.
+          The tutor assumed a lot about me`,
+      };
+      const response = await chai
+        .request(server)
+        .post(`${baseUrl}`)
+        .set('Authorization', adminUser.token)
+        .send(requestObject);
+      const errorMessage = '[resourceId] must be of type: string';
+      expect(response.body.error).to.equal(errorMessage);
+      expect(response.status).to.equal(400);
+    });
+
+    // eslint-disable-next-line max-len
+    it('should not create review with a non-string review input', async () => {
+      const requestObject = {
+        resourceId: existingResourceId,
+        review: [
+          `The video was a little bit too fast.
+          The tutor assumed a lot about me`,
+        ],
+      };
+      const response = await chai
+        .request(server)
+        .post(`${baseUrl}`)
+        .set('Authorization', adminUser.token)
+        .send(requestObject);
+      const errorMessage = '[review] must be of type: string';
+      expect(response.body.error).to.equal(errorMessage);
+      expect(response.status).to.equal(400);
+    });
+  });
+
+  describe('Create Review', () => {
+    it('should successfully create a review', async () => {
+      const requestObject = {
+        resourceId: existingResourceId,
+        review: `The video was too fast. The tutor assumed a lot about me`,
+      };
+      const response = await chai
+        .request(server)
+        .post(`${baseUrl}`)
+        .set('Authorization', adminUser.token)
+        .send(requestObject);
+      expect(response.body.message).to.equal('Sucessfully added Review!');
+      expect(response.status).to.equal(201);
+    });
+
+    it('should not create review if user has already reviewed', async () => {
+      const requestObject = {
+        resourceId: existingResourceId,
+        review: `The video was too fast. The tutor assumed a lot about me`,
+      };
+      const response = await chai
+        .request(server)
+        .post(`${baseUrl}`)
+        .set('Authorization', adminUser.token)
+        .send(requestObject);
+      const errorMessage = `userId: ${
+        adminUser.user.id
+      } already exists for resourceId: ${requestObject.resourceId}`;
+      expect(response.body.error).to.equal(errorMessage);
+      expect(response.status).to.equal(409);
+    });
+  });
+
+  describe('Get Reviews', () => {
+    it('should not get reviews if resourceId does not exist', async () => {
+      const response = await chai
+        .request(server)
+        .get(`${baseUrl}/nonexistent-resource-id`);
+      const errorMessage =
+        'Resource with id: nonexistent-resource-id does not exist';
+      expect(response.body.error).to.equal(errorMessage);
+      expect(response.status).to.equal(404);
+    });
+
+    it('should successfully get reviews', async () => {
+      const response = await chai
+        .request(server)
+        .get(`${baseUrl}/${existingResourceId}`);
+      expect(response.body).to.haveOwnProperty('reviews');
+      expect(Array.isArray(response.body.reviews)).to.equal(true);
+      expect(response.status).to.equal(200);
+    });
+  });
+});

--- a/src/app/review/controller.js
+++ b/src/app/review/controller.js
@@ -1,0 +1,32 @@
+import models from '../../database/models';
+
+const { Review } = models;
+
+const createReview = async (req, res) => {
+  const { resourceId, review } = req.body;
+  const userId = req.decoded.id;
+  const userReview = await Review.create({
+    userId: userId.trim(),
+    resourceId: resourceId.toLowerCase().trim(),
+    review: review.toLowerCase().trim(),
+  });
+  return res.status(201).json({
+    message: 'Sucessfully added Review!',
+    review: userReview,
+  });
+};
+
+const getReviews = async (req, res) => {
+  const { resourceId } = req.params;
+  const reviews = await Review.findAndCountAll({
+    where: { resourceId },
+    order: [['createdAt', 'DESC']],
+  });
+
+  return res.status(200).json({
+    reviews: reviews.rows,
+    count: reviews.count,
+  });
+};
+
+export { createReview, getReviews };

--- a/src/app/review/index.js
+++ b/src/app/review/index.js
@@ -1,0 +1,1 @@
+export { default } from './routes';

--- a/src/app/review/middleware.js
+++ b/src/app/review/middleware.js
@@ -1,0 +1,37 @@
+import {
+  requiredParamsValidator,
+  typeValidator,
+  referencedParamValidator,
+  relationalValidator,
+} from '../../common';
+
+const areRequiredParamsPresent = (req, res, next) => {
+  const requiredParams = ['resourceId', 'review'];
+  return requiredParamsValidator(req.body, requiredParams, next);
+};
+
+const areTypesValid = (req, res, next) => {
+  const { resourceId, review } = req.body;
+  const stringParams = { resourceId, review };
+  return typeValidator(stringParams, 'string', next);
+};
+
+const doesResourceExist = (req, res, next) => {
+  const { resourceId } = req.method === 'GET' ? req.params : req.body;
+  referencedParamValidator({ id: resourceId }, 'Resource', next);
+};
+
+const isReviewUniqueForUser = async (req, res, next) => {
+  const {
+    decoded: { id: userId },
+    body: { resourceId },
+  } = req;
+  relationalValidator({ userId, resourceId }, 'Review', next);
+};
+
+export {
+  areRequiredParamsPresent,
+  isReviewUniqueForUser,
+  doesResourceExist,
+  areTypesValid,
+};

--- a/src/app/review/routes.js
+++ b/src/app/review/routes.js
@@ -1,0 +1,26 @@
+import express from 'express';
+import { isTokenValid } from '../../common';
+import { createReview, getReviews } from './controller';
+import {
+  areTypesValid,
+  doesResourceExist,
+  isReviewUniqueForUser,
+  areRequiredParamsPresent,
+} from './middleware';
+
+const reviewRoutes = express.Router();
+
+reviewRoutes
+  .route('/')
+  .post(
+    isTokenValid,
+    areTypesValid,
+    areRequiredParamsPresent,
+    doesResourceExist,
+    isReviewUniqueForUser,
+    createReview,
+  );
+
+reviewRoutes.route('/:resourceId').get(doesResourceExist, getReviews);
+
+export default reviewRoutes;

--- a/src/app/subtopic/_tests_/subtopic.spec.js
+++ b/src/app/subtopic/_tests_/subtopic.spec.js
@@ -159,9 +159,9 @@ describe('Subtopic test suite', () => {
         .post(`${baseUrl}`)
         .set('Authorization', adminUser.token)
         .send(requestObject);
-      const errorMessage = `${requestObject.name} already exists for topicId: ${
-        requestObject.topicId
-      }`;
+      const errorMessage = `name: ${
+        requestObject.name
+      } already exists for topicId: ${requestObject.topicId}`;
       expect(response.body.error).to.equal(errorMessage);
       expect(response.status).to.equal(409);
     });

--- a/src/app/topic/_tests_/topic.spec.js
+++ b/src/app/topic/_tests_/topic.spec.js
@@ -171,7 +171,7 @@ describe('Topic test suite', () => {
         .set('Authorization', adminUser.token)
         .send(requestObject);
       // eslint-disable-next-line max-len
-      const errorMessage = `${
+      const errorMessage = `name: ${
         requestObject.name
       } already exists for technology: ${newTechnology.name}`;
       expect(response.body.error).to.equal(errorMessage);

--- a/src/common/helpers/paramValidator.js
+++ b/src/common/helpers/paramValidator.js
@@ -96,14 +96,16 @@ const relationalValidator = async (params, model, next) => {
   const paramsValue = Object.values(params);
   const rowExists = await models[model].findOne({
     where: {
-      [paramsKey[0]]: { [iLike]: paramsValue[0] },
-      [paramsKey[1]]: { [iLike]: paramsValue[1] },
+      [paramsKey[0]]: { [iLike]: paramsValue[0] && paramsValue[0].trim() },
+      [paramsKey[1]]: { [iLike]: paramsValue[1] && paramsValue[1].trim() },
     },
   });
 
   if (rowExists) {
     const error = new Error(
-      `${paramsValue[0]} already exists for ${paramsKey[1]}: ${paramsValue[1]}`,
+      `${paramsKey[0]}: ${paramsValue[0]} already exists for ${paramsKey[1]}: ${
+        paramsValue[1]
+      }`,
     );
     error.status = 409;
     return next(error);

--- a/src/database/models/resource.js
+++ b/src/database/models/resource.js
@@ -43,7 +43,7 @@ export default (sequelize, DataTypes) => {
       onDelete: 'CASCADE',
     });
     Resource.hasMany(models.Review, {
-      foreignKey: 'id',
+      foreignKey: 'resourceId',
       onDelete: 'CASCADE',
     });
   };

--- a/src/database/models/review.js
+++ b/src/database/models/review.js
@@ -21,10 +21,10 @@ export default (sequelize, DataTypes) => {
 
   Review.associate = models => {
     Review.belongsTo(models.User, {
-      foreignKey: 'proficiencyId',
+      foreignKey: 'userId',
     });
     Review.belongsTo(models.Resource, {
-      foreignKey: 'proficiencyId',
+      foreignKey: 'resourceId',
     });
   };
 

--- a/src/database/models/user.js
+++ b/src/database/models/user.js
@@ -48,6 +48,9 @@ export default (sequelize, DataTypes) => {
     User.hasMany(models.Proficiency, {
       foreignKey: 'userId',
     });
+    User.hasMany(models.Review, {
+      foreignKey: 'userId',
+    });
   };
 
   User.prototype.hashPassword = async function hashPassword() {

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import {
   topicRoutes,
   subtopicRoutes,
   resourceRoutes,
+  reviewRoutes,
 } from './app';
 import { notFoundRoute, errorHandler } from './common';
 import { Api } from '../docs';
@@ -44,6 +45,7 @@ app.use('/api/v1/technologies', technologyRoutes);
 app.use('/api/v1/topics', topicRoutes);
 app.use('/api/v1/subtopics', subtopicRoutes);
 app.use('/api/v1/resources', resourceRoutes);
+app.use('/api/v1/reviews', reviewRoutes);
 app.use(notFoundRoute);
 app.use(errorHandler);
 


### PR DESCRIPTION
#### What does this PR do?
- adds controller for reviews
- adds middleware for reviews
- adds routes for reviews
- refactors error message in relationalValidator and respective tests
- refactors user-review association

#### Description of Task to be completed?
- We need to implement the `CREATE`, `READ` operations for our review model so that users can review resources

#### Acceptance criteria/ Way to Manually test
- As an authenticated user,
  - I should be able to send a `POST` request to `/api/v1/reviews` with the required fields: `resourceId`, `review`
  - I should receive an error message if I'm not authenticated
  - I should receive an error message if the resourceId input does not exist in the database resource table
  - I should receive an error message if the user has already reviewed the resource
- As a user,
  - I should be able to send a `GET` request to `/api/v1/reviews/:resourceId`
  - I should receive an error message if the resource does not exist
  - I should successfully receive reviews for an existing resource
- Tests should be written to cover every line

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#166487873](https://www.pivotaltracker.com/story/show/166487873)