### PR TITLE
#166672704 Implement getTopics feature

### DIFF
--- a/src/app/technology/controller.js
+++ b/src/app/technology/controller.js
@@ -23,6 +23,7 @@ const addTechnology = async (req, res) => {
 };
 
 const getTechnologies = async (req, res) => {
+  /* istanbul ignore next */
   const userId = (req.decoded && req.decoded.id) || '';
   const technologies = await Technology.findAndCountAll({
     order: [['createdAt', 'DESC']],
@@ -34,6 +35,7 @@ const getTechnologies = async (req, res) => {
             model: Proficiency,
             where: { userId },
             attributes: ['proficiency'],
+            required: false,
           },
         ],
       },
@@ -48,11 +50,21 @@ const getTechnologies = async (req, res) => {
 
 const getSingleTechnology = async (req, res) => {
   const { name } = req.params;
+  /* istanbul ignore next */
+  const userId = (req.decoded && req.decoded.id) || '';
   const technology = await Technology.findOne({
     where: { name: { [iLike]: name } },
     include: [
       {
         model: Topic,
+        include: [
+          {
+            model: Proficiency,
+            where: { userId },
+            attributes: ['proficiency'],
+            required: false,
+          },
+        ],
       },
     ],
   });

--- a/src/app/technology/routes.js
+++ b/src/app/technology/routes.js
@@ -28,6 +28,8 @@ technologyRoutes
   );
 
 technologyRoutes.route('/').get(getUserId, getTechnologies);
-technologyRoutes.route('/:name').get(doesTechnologyExist, getSingleTechnology);
+technologyRoutes
+  .route('/:name')
+  .get(getUserId, doesTechnologyExist, getSingleTechnology);
 
 export default technologyRoutes;

--- a/src/app/topic/_tests_/topic.spec.js
+++ b/src/app/topic/_tests_/topic.spec.js
@@ -30,7 +30,7 @@ describe('Topic test suite', () => {
     });
 
     const requestObject = {
-      name: 'c#',
+      name: 'golang',
       category: 'backend',
     };
     newTechnology = (await chai
@@ -44,7 +44,7 @@ describe('Topic test suite', () => {
     it('should successfully create a topic', async () => {
       const requestObject = {
         name: 'Random topic',
-        technology: 'c#',
+        technology: 'golang',
       };
       const response = await chai
         .request(server)
@@ -58,7 +58,7 @@ describe('Topic test suite', () => {
     it('should successfully create multiple topics', async () => {
       const requestObject = {
         name: ['Random', 'topic'],
-        technology: 'c#',
+        technology: 'golang',
       };
       const response = await chai
         .request(server)
@@ -190,6 +190,27 @@ describe('Topic test suite', () => {
       } already exists for technology: ${newTechnology.name}`;
       expect(response.body.error).to.equal(errorMessage);
       expect(response.status).to.equal(409);
+    });
+  });
+
+  describe('Get Topics', () => {
+    it('should successfully get all topics in a technology', async () => {
+      const response = await chai
+        .request(server)
+        .get(`${baseUrl}/topics/${newTechnology.name}`);
+      expect(response.body).to.haveOwnProperty('topics');
+      expect(Array.isArray(response.body.topics)).to.equal(true);
+      expect(response.status).to.equal(200);
+    });
+
+    it('should not get topics if technology does not exist', async () => {
+      const response = await chai
+        .request(server)
+        .get(`${baseUrl}/topics/nonexistent-technology`);
+      const errorMessage =
+        'Technology with name: nonexistent-technology does not exist';
+      expect(response.body.error).to.equal(errorMessage);
+      expect(response.status).to.equal(404);
     });
   });
 });

--- a/src/app/topic/middleware.js
+++ b/src/app/topic/middleware.js
@@ -23,9 +23,14 @@ const areTypesValid = (req, res, next) => {
   return typeValidator(stringParams, 'string', next);
 };
 
-const isTechnologyExisting = (req, res, next) => {
+const doesTechnologyExist = (req, res, next) => {
   referencedParamValidator(
-    { name: req.body.technology.trim() },
+    {
+      name:
+        req.method === 'GET'
+          ? req.params.technology
+          : req.body.technology.trim(),
+    },
     'Technology',
     next,
   );
@@ -65,6 +70,6 @@ const isNameUniqueForTechnology = async (req, res, next) => {
 export {
   areRequiredParamsPresent,
   areTypesValid,
-  isTechnologyExisting,
+  doesTechnologyExist,
   isNameUniqueForTechnology,
 };

--- a/src/app/topic/routes.js
+++ b/src/app/topic/routes.js
@@ -1,11 +1,11 @@
 import express from 'express';
-import createTopic from './controller';
-import { isUserAdmin, isTokenValid } from '../../common';
+import { createTopic, getTopics } from './controller';
+import { isUserAdmin, isTokenValid, getUserId } from '../../common';
 import {
   areRequiredParamsPresent,
   areTypesValid,
   isNameUniqueForTechnology,
-  isTechnologyExisting,
+  doesTechnologyExist,
 } from './middleware';
 
 const topicRoutes = express.Router();
@@ -18,8 +18,12 @@ topicRoutes
     areTypesValid,
     areRequiredParamsPresent,
     isNameUniqueForTechnology,
-    isTechnologyExisting,
+    doesTechnologyExist,
     createTopic,
   );
+
+topicRoutes
+  .route('/:technology')
+  .get(getUserId, doesTechnologyExist, getTopics);
 
 export default topicRoutes;

--- a/src/database/migrations/004-create-topic.js
+++ b/src/database/migrations/004-create-topic.js
@@ -4,7 +4,7 @@ module.exports = {
       id: {
         allowNull: false,
         primaryKey: true,
-        type: Sequelize.UUID,
+        type: Sequelize.STRING,
         defaultValue: Sequelize.UUIDV4,
       },
       name: {


### PR DESCRIPTION
#### What does this PR do?
- adds getTopics controller
- adds getTopics route
- adds getTopics middleware
- adds clause: (required: false) in getTechnology include model for proficiency
- renames middleware `isTechnologyExisting` to `doesTechnology Exist`

#### Description of Task to be completed?
As a user,
I should also be able to get all the topics for a particular technology with their accompanying subtopics, resources and reviews

#### How should this be manually tested?
- Send a `GET` request to `/api/v1/topics/:technology`
- If your provided technology exists, you should receive a response with all the topics for that technology

#### What are the relevant pivotal tracker stories?
[#166672704](https://www.pivotaltracker.com/story/show/166672704)